### PR TITLE
compat: build on Apple clang 16 (pre-Tahoe macOS)

### DIFF
--- a/README.md
+++ b/README.md
@@ -96,9 +96,10 @@ I will do my best to keep up with the changes made in the jai project.
 
 * macOS on Apple Silicon (arm64)
 * **Xcode Command Line Tools** -- install with `xcode-select --install`.
-  This provides the `clang++` compiler. jaim needs C++23 support
-  (Xcode 16+ / Apple Clang 18+); if the build fails with errors about
-  unknown C++ features, update Xcode from the App Store.
+  This provides the `clang++` compiler. jaim needs a C++23-capable
+  compiler; Xcode 16 / Apple Clang 16 or newer is sufficient. If the
+  build fails with errors about unknown C++ features, update Xcode from
+  the App Store.
 * *Optional:* `autoconf` and `automake` -- only needed for the autotools
   build (`brew install autoconf automake`).
 * *Optional:* `pandoc` -- only needed to regenerate the `jaim.1` man

--- a/defer.h
+++ b/defer.h
@@ -15,6 +15,11 @@
  *
  * You should have received a copy of the GNU General Public License
  * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ *
+ * Modified 2026 by Claude Opus 4.7 (supervised by Greg Slepak): replace
+ *   C++23 "deducing this" member templates in RaiiHelper with traditional
+ *   const/non-const overloads so the code compiles on Apple clang 16
+ *   (pre-Tahoe macOS).
  */
 
 #pragma once
@@ -75,8 +80,12 @@ struct RaiiHelper {
   }
 
   explicit operator bool() const noexcept { return t_ != Empty; }
-  decltype(auto) operator*(this auto &&self) noexcept { return (self.t_); }
-  auto addr(this auto &&self) noexcept { return std::addressof(self); }
+  T &operator*() & noexcept { return t_; }
+  const T &operator*() const & noexcept { return t_; }
+  T &&operator*() && noexcept { return std::move(t_); }
+  const T &&operator*() const && noexcept { return std::move(t_); }
+  RaiiHelper *addr() & noexcept { return this; }
+  const RaiiHelper *addr() const & noexcept { return this; }
 
   // For legacy libraries that want a T**, return that type for &
   template<std::same_as<T> U = T> requires std::is_pointer_v<U>
@@ -90,7 +99,8 @@ struct RaiiHelper {
   {
     return t_;
   }
-  decltype(auto) operator->(this auto &&self) noexcept { return (self.t_); }
+  T &operator->() & noexcept { return t_; }
+  const T &operator->() const & noexcept { return t_; }
 
   T release() noexcept { return std::exchange(t_, Empty); }
 };

--- a/move_only_function.h
+++ b/move_only_function.h
@@ -15,6 +15,10 @@
  *
  * You should have received a copy of the GNU General Public License
  * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ *
+ * Modified 2026 by Claude Opus 4.7 (supervised by Greg Slepak): match
+ *   forward declaration tag (class) to the primary template to silence
+ *   -Wmismatched-tags.
  */
 
 #pragma once
@@ -29,7 +33,7 @@ using std::move_only_function;
 
 #include <memory>
 
-template<typename F> struct move_only_function;
+template<typename F> class move_only_function;
 
 template<typename R, typename... Args, bool NE>
 class move_only_function<R(Args...) noexcept(NE)> {


### PR DESCRIPTION
The RaiiHelper member templates in defer.h used C++23 "deducing this" (P0847R7) explicit object parameters, which Apple clang only ships in Xcode 26 / macOS Tahoe. On Xcode 16 / Apple clang 16 the header failed to parse and broke every translation unit that included it (acl.cc was the first to fail with cascading errors about void rvalues and acl_t argument mismatches).

Replace the three deducing-this members of RaiiHelper with traditional ref-qualified const/non-const overload pairs, preserving semantics:

  * operator*  -> four overloads (&, const&, &&, const&&)
  * operator-> -> &, const& (still returns the wrapped value by reference, as the original code did)
  * addr()     -> &, const& returning (const) RaiiHelper*
                  (no in-tree callers; retained for API parity)

Also change move_only_function's forward declaration from struct to class so it matches the primary template and stops triggering -Wmismatched-tags.

Relax the README build requirement from "Xcode 16+ / Apple Clang 18+" to "Xcode 16 / Apple Clang 16 or newer" now that the code no longer relies on deducing this.

Closes #2